### PR TITLE
[Fix] Convert finalEnd to milliseconds when provided

### DIFF
--- a/mp3chap.go
+++ b/mp3chap.go
@@ -87,6 +87,8 @@ func main() {
 		finalEnd, err = strconv.ParseUint(os.Args[x], 10, 32)
 		if err != nil {
 			log.Fatal("failed parsing final seconds %#v: %v", os.Args[x], err)
+		} else {
+			finalEnd = uint64(finalEnd * 1000)
 		}
 	}
 


### PR DESCRIPTION
cc @jcs for review

When the `TLEN` ID3 tag is not present, we can supply the audio duration (in seconds) as the last argument. This isn't working as expected, however, because all other timestamps are in milliseconds.

After writing chapters to an MP3 file, we can see the issue here on the last chapter of the audio file:

```
$ ffprobe audio.mp3
[mp3 @ 0x55acfe8d0080] Chapter end time 2297 before start 2274000 
```

This PR converts `finalEnd` to milliseconds when it's provided so that it matches all other timestamps in the file and works as expected.